### PR TITLE
Added a conformsToProtocol matcher

### DIFF
--- a/Source/Library/Object/HCConformsToProtocol.h
+++ b/Source/Library/Object/HCConformsToProtocol.h
@@ -1,0 +1,42 @@
+//
+//  OCHamcrest - HCConformsToProtocol.h
+//  Copyright 2011 hamcrest.org. See LICENSE.txt
+//
+//  Created by: Todd Farrell
+//
+
+#import <OCHamcrest/HCBaseMatcher.h>
+
+
+@interface HCConformsToProtocol : HCBaseMatcher
+{
+    Protocol *theProtocol;
+}
+
++ (id)conformsToProtocol:(Protocol *)protocol;
+- (id)initWithProtocol:(Protocol *)protocol;
+
+@end
+
+
+OBJC_EXPORT id<HCMatcher> HC_conformsToProtocol(Protocol *aProtocol);
+
+/**
+ conformsToProtocol(aProtocol) -
+ Matches if object conforms to a given protocol.
+ 
+ @param aProtocol  The protocol to compare against as the expected protocol.
+ 
+ This matcher checks whether the evaluated object conforms to @a aProtocol.
+ 
+ Example:
+ @li @ref conformsToProtocol(@protocol(NSObject))
+ 
+ (In the event of a name clash, don't \#define @c HC_SHORTHAND and use the synonym
+ @c HC_conformsToProtocol instead.)
+ 
+ @ingroup object_matchers
+ */
+#ifdef HC_SHORTHAND
+#define conformsToProtocol HC_conformsToProtocol
+#endif

--- a/Source/Library/Object/HCConformsToProtocol.mm
+++ b/Source/Library/Object/HCConformsToProtocol.mm
@@ -1,0 +1,50 @@
+//
+//  OCHamcrest - HCConformsToProtocol.mm
+//  Copyright 2011 hamcrest.org. See LICENSE.txt
+//
+//  Created by: Todd Farrell
+//
+
+#import "HCConformsToProtocol.h"
+
+#import "HCDescription.h"
+#import "HCRequireNonNilObject.h"
+
+
+@implementation HCConformsToProtocol
+
++ (id)conformsToProtocol:(Protocol *)protocol
+{
+    return [[[self alloc] initWithProtocol:protocol] autorelease];
+}
+
+- (id)initWithProtocol:(Protocol *)aProtocol
+{
+    HCRequireNonNilObject(aProtocol);
+    
+    self = [super init];
+    if (self)
+        theProtocol = aProtocol;
+    return self;
+}
+
+- (BOOL)matches:(id)item
+{
+    return [item conformsToProtocol:theProtocol];
+}
+
+- (void)describeTo:(id<HCDescription>)description
+{
+    [[description appendText:@"an object that conforms to "]
+     appendText:NSStringFromProtocol(theProtocol)];
+}
+
+@end
+
+
+#pragma mark -
+
+OBJC_EXPORT id<HCMatcher> HC_conformsToProtocol(Protocol *aProtocol)
+{
+    return [HCConformsToProtocol conformsToProtocol:aProtocol];
+}

--- a/Source/MainPage.h
+++ b/Source/MainPage.h
@@ -109,6 +109,7 @@
         <li>@ref hasDescription - match object's @c -description</li>
 		<li>@ref hasProperty - match return value of method with given name</li>
         <li>@ref instanceOf - match object type</li>
+        <li>@ref conformsToProtocol - match object protocol conformance</li>
         <li>@ref nilValue, @ref notNilValue - match for @c nil, or not @c nil</li>
         <li>@ref sameInstance - match same object</li>
         </ul>

--- a/Source/OCHamcrest.h
+++ b/Source/OCHamcrest.h
@@ -18,6 +18,7 @@
 
     @ingroup library
  */
+#import <OCHamcrest/HCConformsToProtocol.h>
 #import <OCHamcrest/HCHasDescription.h>
 #import <OCHamcrest/HCHasProperty.h>
 #import <OCHamcrest/HCIsEqual.h>

--- a/Source/OCHamcrest.xcodeproj/project.pbxproj
+++ b/Source/OCHamcrest.xcodeproj/project.pbxproj
@@ -227,6 +227,11 @@
 		088FB0AF136A70B800C191E1 /* HCStringContainsInOrder.h in Headers */ = {isa = PBXBuildFile; fileRef = 088FB0AD136A70B800C191E1 /* HCStringContainsInOrder.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		088FB0B1136A70B800C191E1 /* HCStringContainsInOrder.mm in Sources */ = {isa = PBXBuildFile; fileRef = 088FB0AE136A70B800C191E1 /* HCStringContainsInOrder.mm */; };
 		088FB0B2136A70B800C191E1 /* HCStringContainsInOrder.mm in Sources */ = {isa = PBXBuildFile; fileRef = 088FB0AE136A70B800C191E1 /* HCStringContainsInOrder.mm */; };
+		5F2773401436F50C00B9683A /* HCConformsToProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 5F27733E1436F50C00B9683A /* HCConformsToProtocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5F2773411436F50C00B9683A /* HCConformsToProtocol.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5F27733F1436F50C00B9683A /* HCConformsToProtocol.mm */; };
+		5F2773471436FA9D00B9683A /* HCConformsToProtocol.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5F27733F1436F50C00B9683A /* HCConformsToProtocol.mm */; };
+		5F2773481436FAA600B9683A /* ConformsToProtocolTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 5F2773441436F81000B9683A /* ConformsToProtocolTest.m */; };
+		5F2773491436FAA700B9683A /* ConformsToProtocolTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 5F2773441436F81000B9683A /* ConformsToProtocolTest.m */; };
 		77C7B86D14292D5100DE60CC /* HCHasProperty.h in Headers */ = {isa = PBXBuildFile; fileRef = 77C7B86B14292D5100DE60CC /* HCHasProperty.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		77C7B86E14292D5100DE60CC /* HCHasProperty.mm in Sources */ = {isa = PBXBuildFile; fileRef = 77C7B86C14292D5100DE60CC /* HCHasProperty.mm */; };
 		77C7B8771429361200DE60CC /* HasPropertyTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 77C7B8761429361200DE60CC /* HasPropertyTest.m */; };
@@ -398,6 +403,9 @@
 		08BDD5FD1350C7BE00E5A443 /* MakeDistribution.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = MakeDistribution.sh; sourceTree = "<group>"; };
 		08BDD5FE1350C7BE00E5A443 /* MakeDocumentation.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = MakeDocumentation.sh; sourceTree = "<group>"; };
 		08BDD5FF1350C7BE00E5A443 /* MakeIOSFramework.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = MakeIOSFramework.sh; sourceTree = "<group>"; };
+		5F27733E1436F50C00B9683A /* HCConformsToProtocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HCConformsToProtocol.h; sourceTree = "<group>"; };
+		5F27733F1436F50C00B9683A /* HCConformsToProtocol.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = HCConformsToProtocol.mm; sourceTree = "<group>"; };
+		5F2773441436F81000B9683A /* ConformsToProtocolTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ConformsToProtocolTest.m; sourceTree = "<group>"; };
 		77C7B86B14292D5100DE60CC /* HCHasProperty.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HCHasProperty.h; sourceTree = "<group>"; };
 		77C7B86C14292D5100DE60CC /* HCHasProperty.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = HCHasProperty.mm; sourceTree = "<group>"; };
 		77C7B8761429361200DE60CC /* HasPropertyTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HasPropertyTest.m; sourceTree = "<group>"; };
@@ -643,6 +651,8 @@
 		087602F013440A9F001B439B /* Object */ = {
 			isa = PBXGroup;
 			children = (
+				5F27733E1436F50C00B9683A /* HCConformsToProtocol.h */,
+				5F27733F1436F50C00B9683A /* HCConformsToProtocol.mm */,
 				087602F113440A9F001B439B /* HCHasDescription.h */,
 				087602F213440A9F001B439B /* HCHasDescription.mm */,
 				77C7B86B14292D5100DE60CC /* HCHasProperty.h */,
@@ -731,6 +741,7 @@
 		0876035713440AD8001B439B /* Object */ = {
 			isa = PBXGroup;
 			children = (
+				5F2773441436F81000B9683A /* ConformsToProtocolTest.m */,
 				0876035813440AD8001B439B /* HasDescriptionTest.m */,
 				77C7B8761429361200DE60CC /* HasPropertyTest.m */,
 				0846B6F313EE5FD200EA68E8 /* IsEqualTest.m */,
@@ -837,6 +848,7 @@
 				0846B6CD13EE5D8A00EA68E8 /* HCIsNil.h in Headers */,
 				0846B6D113EE5D8A00EA68E8 /* HCIsSame.h in Headers */,
 				77C7B86D14292D5100DE60CC /* HCHasProperty.h in Headers */,
+				5F2773401436F50C00B9683A /* HCConformsToProtocol.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1046,6 +1058,7 @@
 				0846B6D013EE5D8A00EA68E8 /* HCIsNil.mm in Sources */,
 				0846B6D413EE5D8A00EA68E8 /* HCIsSame.mm in Sources */,
 				77C7B87914293CC500DE60CC /* HCHasProperty.mm in Sources */,
+				5F2773471436FA9D00B9683A /* HCConformsToProtocol.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1094,6 +1107,7 @@
 				082E7C3613FF676E004A22FE /* InvocationMatcherTest.m in Sources */,
 				082E7C3813FF676E004A22FE /* StringDescriptionTest.m in Sources */,
 				77C7B87A14293D0700DE60CC /* HasPropertyTest.m in Sources */,
+				5F2773491436FAA700B9683A /* ConformsToProtocolTest.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1145,6 +1159,7 @@
 				0846B6CF13EE5D8A00EA68E8 /* HCIsNil.mm in Sources */,
 				0846B6D313EE5D8A00EA68E8 /* HCIsSame.mm in Sources */,
 				77C7B86E14292D5100DE60CC /* HCHasProperty.mm in Sources */,
+				5F2773411436F50C00B9683A /* HCConformsToProtocol.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1193,6 +1208,7 @@
 				082E7C3513FF676E004A22FE /* InvocationMatcherTest.m in Sources */,
 				082E7C3713FF676E004A22FE /* StringDescriptionTest.m in Sources */,
 				77C7B8771429361200DE60CC /* HasPropertyTest.m in Sources */,
+				5F2773481436FAA600B9683A /* ConformsToProtocolTest.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Source/Tests/Object/ConformsToProtocolTest.m
+++ b/Source/Tests/Object/ConformsToProtocolTest.m
@@ -1,0 +1,75 @@
+//
+//  OCHamcrest - ConformsToProtocolTest.m
+//  Copyright 2011 hamcrest.org. See LICENSE.txt
+//
+//  Created by: Todd Farrell
+//
+
+    // Class under test
+#define HC_SHORTHAND
+#import <OCHamcrest/HCConformsToProtocol.h>
+
+    // Test support
+#import "AbstractMatcherTest.h"
+
+
+@interface ConformsToProtocolTest : AbstractMatcherTest
+@end
+
+@protocol TestProtocol
+@end
+
+@interface TestClass : NSObject <TestProtocol>
+@end
+
+@implementation TestClass
+
++ (TestClass *)testClass {
+    return [[[TestClass alloc] init] autorelease];
+}
+
+@end
+
+@implementation ConformsToProtocolTest
+
+- (id<HCMatcher>)createMatcher
+{
+    return conformsToProtocol(@protocol(TestProtocol));
+}
+
+- (void)testEvaluatesToTrueIfArgumentConformsToASpecificProtocol
+{
+    TestClass *instance = [TestClass testClass];
+
+    assertMatches(@"conforms to protocol", conformsToProtocol(@protocol(TestProtocol)), instance);
+
+    assertDoesNotMatch(@"does not conform to protocol", conformsToProtocol(@protocol(TestProtocol)), @"hi");
+    assertDoesNotMatch(@"nil", conformsToProtocol(@protocol(TestProtocol)), nil);
+}
+
+- (void)testMatcherCreationRequiresNonNilArgument
+{
+    STAssertThrows(conformsToProtocol(nil), @"Should require non-nil argument");
+}
+
+- (void)testHasAReadableDescription
+{
+    assertDescription(@"an object that conforms to TestProtocol", conformsToProtocol(@protocol(TestProtocol)));
+}
+
+- (void)testSuccessfulMatchDoesNotGenerateMismatchDescription
+{
+    assertNoMismatchDescription(conformsToProtocol(@protocol(NSObject)), @"hi");
+}
+
+- (void)testMismatchDescriptionShowsActualArgument
+{
+    assertMismatchDescription(@"was \"bad\"", conformsToProtocol(@protocol(TestProtocol)), @"bad");
+}
+
+- (void)testDescribeMismatch
+{
+    assertDescribeMismatch(@"was \"bad\"", conformsToProtocol(@protocol(TestProtocol)), @"bad");
+}
+
+@end


### PR DESCRIPTION
I had trouble running the unit tests with the 'libochamcrestTests' target but they pass for OCHamcrestTests.  Let me know if there is anything that needs work before you could consider accepting this change.

Thanks for doing great work on OCHamcrest :-)
