### PR TITLE
Fix format string warnings in Xcode 4.4

### DIFF
--- a/Source/Core/HCBaseDescription.m
+++ b/Source/Core/HCBaseDescription.m
@@ -47,7 +47,7 @@
     NSString *description = [value description];
     NSUInteger descriptionLength = [description length];
     if (descriptionLength == 0)
-        [self append:[NSString stringWithFormat:@"<%@: 0x%0x>", NSStringFromClass([value class]), value]];
+        [self append:[NSString stringWithFormat:@"<%@: 0x%0x>", NSStringFromClass([value class]), (unsigned int)value]];
     else if ([description characterAtIndex:0] == '<'
              && [description characterAtIndex:descriptionLength - 1] == '>')
     {

--- a/Source/Core/HCBaseMatcher.m
+++ b/Source/Core/HCBaseMatcher.m
@@ -54,7 +54,7 @@
 {
     NSString *className = NSStringFromClass([self class]);
     [NSException raise:NSGenericException
-                format:@"-[%@  %s] not implemented", className, command];
+                format:@"-[%@  %s] not implemented", className, (char *)command];
 }
 
 @end

--- a/Source/Library/Collection/HCIsCollectionContainingInOrder.m
+++ b/Source/Library/Collection/HCIsCollectionContainingInOrder.m
@@ -87,7 +87,7 @@
 
 - (void)describeMismatchOfMatcher:(id<HCMatcher>)matcher item:(id)item
 {
-    [mismatchDescription appendText:[NSString stringWithFormat:@"item %d: ", nextMatchIndex]];
+    [mismatchDescription appendText:[NSString stringWithFormat:@"item %ld: ", nextMatchIndex]];
     [matcher describeMismatchOf:item to:mismatchDescription];
 }
 

--- a/Source/Library/Object/HCIsSame.m
+++ b/Source/Library/Object/HCIsSame.m
@@ -42,13 +42,13 @@
 {
     [mismatchDescription appendText:@"was "];
     if (item)
-        [mismatchDescription appendText:[NSString stringWithFormat:@"0x%0x ", item]];
+        [mismatchDescription appendText:[NSString stringWithFormat:@"0x%0x ", (unsigned int)item]];
     [mismatchDescription appendDescriptionOf:item];
 }
 
 - (void)describeTo:(id<HCDescription>)description
 {
-    [[description appendText:[NSString stringWithFormat:@"same instance as 0x%0x ", object]]
+    [[description appendText:[NSString stringWithFormat:@"same instance as 0x%0x ", (unsigned int)object]]
          appendDescriptionOf:object];
 }
 


### PR DESCRIPTION
Fwiw, unit tests in OCHamcrest.xcodeproj continue to pass with these changes.
