### PR TITLE
Better description for equalToBool

### DIFF
--- a/Source/Library/Number/HCIsEqualToNumber.h
+++ b/Source/Library/Number/HCIsEqualToNumber.h
@@ -30,6 +30,15 @@ OBJC_EXPORT id<HCMatcher> HC_equalToBool(BOOL value);
     #define equalToBool HC_equalToBool
 #endif
 
+@interface HCIsEqualToBool : HCBaseMatcher
+{
+    BOOL value;
+}
+
+- (id)initWithValue:(BOOL)aValue;
+
+@end
+
 
 OBJC_EXPORT id<HCMatcher> HC_equalToChar(char value);
 

--- a/Source/Library/Number/HCIsEqualToNumber.m
+++ b/Source/Library/Number/HCIsEqualToNumber.m
@@ -10,6 +10,7 @@
 #import "HCIsEqualToNumber.h"
 
 #import "HCIsEqual.h"
+#import "HCDescription.h"
 
 
 #define DEFINE_EQUAL_TO_NUMBER(name, type)                                  \
@@ -18,7 +19,6 @@
         return [HCIsEqual isEqualTo:[NSNumber numberWith ## name :value]];  \
     }
 
-DEFINE_EQUAL_TO_NUMBER(Bool, BOOL)
 DEFINE_EQUAL_TO_NUMBER(Char, char)
 DEFINE_EQUAL_TO_NUMBER(Double, double)
 DEFINE_EQUAL_TO_NUMBER(Float, float)
@@ -33,3 +33,49 @@ DEFINE_EQUAL_TO_NUMBER(UnsignedLongLong, unsigned long long)
 DEFINE_EQUAL_TO_NUMBER(UnsignedShort, unsigned short)
 DEFINE_EQUAL_TO_NUMBER(Integer, NSInteger)
 DEFINE_EQUAL_TO_NUMBER(UnsignedInteger, NSUInteger)
+
+OBJC_EXPORT id<HCMatcher> HC_equalToBool(BOOL value)
+{
+    return [[HCIsEqualToBool alloc] initWithValue:value];
+}
+
+@interface HCIsEqualToBool ()
++ (NSString*) stringForBool:(BOOL)value;
+@end
+
+@implementation HCIsEqualToBool
+
++ (NSString*) stringForBool:(BOOL)value
+{
+    return value ? @"<YES>" : @"<NO>";
+}
+
+- (id)initWithValue:(BOOL)aValue
+{
+    if ((self = [super init])) {
+        value = aValue;
+    }
+    return self;
+}
+
+- (BOOL)matches:(id)item
+{
+    if (![item isKindOfClass:[NSNumber class]])
+        return NO;
+    return [item boolValue] == value;
+}
+
+- (void)describeTo:(id<HCDescription>)description
+{
+    [description appendText:@"a BOOL with the value of "];
+    [description appendText:[HCIsEqualToBool stringForBool:value]];
+}
+
+- (void)describeMismatchOf:(id)item to:(id<HCDescription>)mismatchDescription
+{
+    [mismatchDescription appendText:@"was "];
+    [mismatchDescription appendText:[HCIsEqualToBool stringForBool:[item boolValue]]];
+}
+
+
+@end

--- a/Source/Tests/Number/NumberAssertTest.m
+++ b/Source/Tests/Number/NumberAssertTest.m
@@ -13,6 +13,7 @@
 
     // Collaborators
 #import <OCHamcrest/HCIsEqual.h>
+#import <OCHamcrest/HCIsEqualToNumber.h>
 
     // Test support
 #import <SenTestingKit/SenTestingKit.h>
@@ -43,6 +44,20 @@
     @catch (NSException* exception)
     {
         STAssertEqualObjects([exception reason], @"Expected <0>, but was <1>", nil);
+        return;
+    }
+    STFail(@"should have failed");
+}
+
+- (void)testFailure_withBoolMoreExplicitDescription
+{
+    @try
+    {
+        assertThatBool(YES, equalToBool(NO));
+    }
+    @catch (NSException* exception)
+    {
+        STAssertEqualObjects([exception reason], @"Expected a BOOL with the value of <NO>, but was <YES>", nil);
         return;
     }
     STFail(@"should have failed");


### PR DESCRIPTION
`equalToBool` cases would be easier to read if `BOOL` values were more explicit. This PR adds this functionality.
