### PR TITLE
Fix problem formatting percent symbols.

### DIFF
--- a/Source/Core/HCAssertThat.m
+++ b/Source/Core/HCAssertThat.m
@@ -32,7 +32,12 @@ static NSException *createOCUnitException(const char* fileName, int lineNumber, 
 #pragma clang diagnostic ignored "-Wundeclared-selector"
     SEL selector = @selector(failureInFile:atLine:withDescription:);
 #pragma clang diagnostic pop
-    
+
+    // Description expects a format string, but NSInvocation does not support varargs.
+    // Mask % symbols in the string so they aren't treated as placeholders.
+    description = [description stringByReplacingOccurrencesOfString:@"%"
+                                                         withString:@"%%"];
+
     NSMethodSignature *signature = [[NSException class] methodSignatureForSelector:selector];
     NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];
     [invocation setTarget:[NSException class]];

--- a/Source/Tests/Core/AssertThatTest.m
+++ b/Source/Tests/Core/AssertThatTest.m
@@ -106,6 +106,25 @@
     STFail(@"should have failed");
 }
 
+- (void)testAssertionErrorShouldCorrectlyDescribeStringsWithPercentSymbols
+{
+    NSString *expected = @"%s";
+    NSString *actual = @"%d";
+    NSString *expectedMessage = @"Expected \"%s\", but was \"%d\"";
+
+    @try
+    {
+        [self raiseAfterFailure];
+        assertThat(actual, equalTo(expected));
+    }
+    @catch (NSException* exception)
+    {
+        STAssertTrue([[exception reason] rangeOfString:expectedMessage].location != NSNotFound, nil);
+        return;
+    }
+    STFail(@"should have failed");
+}
+
 - (void)testAssertionRecordingAllErrors
 {
     QuietTest *testCase = [QuietTest testCaseWithSelector:@selector(twoFailingAssertions)];


### PR DESCRIPTION
I noticed that values containing "%" are broken in the error messages. This should fix it.
