### PR TITLE
EXC_BAD_ACCESS in createOCUnitException

### DIFF
--- a/Source/Core/HCAssertThat.m
+++ b/Source/Core/HCAssertThat.m
@@ -38,7 +38,7 @@ static NSException *createOCUnitException(const char* fileName, int lineNumber, 
     [invocation setTarget:[NSException class]];
     [invocation setSelector:selector];
     
-    __unsafe_unretained id fileArg = @(fileName);
+    id fileArg = @(fileName);
     [invocation setArgument:&fileArg atIndex:2];
     [invocation setArgument:&lineNumber atIndex:3];
     [invocation setArgument:&description atIndex:4];


### PR DESCRIPTION
For some reason the crash only occurs in some environments. I guess the autoboxed string is sometimes released and sometimes autoreleased by the compiler.
