### PR TITLE
Fix wrong descriptions in the unordered collection matcher.

### DIFF
--- a/Source/Library/Collection/HCIsCollectionContainingInAnyOrder.h
+++ b/Source/Library/Collection/HCIsCollectionContainingInAnyOrder.h
@@ -12,11 +12,11 @@
 
 @interface HCIsCollectionContainingInAnyOrder : HCBaseMatcher
 {
-    NSMutableArray *matchers;
+    NSArray *matchers;
 }
 
-+ (id)isCollectionContainingInAnyOrder:(NSMutableArray *)itemMatchers;
-- (id)initWithMatchers:(NSMutableArray *)itemMatchers;
++ (id)isCollectionContainingInAnyOrder:(NSArray *)itemMatchers;
+- (id)initWithMatchers:(NSArray *)itemMatchers;
 
 @end
 

--- a/Source/Library/Collection/HCIsCollectionContainingInAnyOrder.m
+++ b/Source/Library/Collection/HCIsCollectionContainingInAnyOrder.m
@@ -24,13 +24,13 @@
 
 @implementation HCMatchingInAnyOrder
 
-- (id)initWithMatchers:(NSMutableArray *)itemMatchers
+- (id)initWithMatchers:(NSArray *)itemMatchers
    mismatchDescription:(id<HCDescription, NSObject>)description
 {
     self = [super init];
     if (self)
     {
-        matchers = itemMatchers;
+        matchers = [itemMatchers mutableCopy];
         mismatchDescription = description;        
     }
     return self;
@@ -71,16 +71,16 @@
 
 @implementation HCIsCollectionContainingInAnyOrder
 
-+ (id)isCollectionContainingInAnyOrder:(NSMutableArray *)itemMatchers
++ (id)isCollectionContainingInAnyOrder:(NSArray *)itemMatchers
 {
     return [[self alloc] initWithMatchers:itemMatchers];
 }
 
-- (id)initWithMatchers:(NSMutableArray *)itemMatchers
+- (id)initWithMatchers:(NSArray *)itemMatchers
 {
     self = [super init];
     if (self)
-        matchers = itemMatchers;
+        matchers = [itemMatchers copy];
     return self;
 }
 

--- a/Source/Tests/Core/AbstractMatcherTest.m
+++ b/Source/Tests/Core/AbstractMatcherTest.m
@@ -77,6 +77,8 @@
                 inFile:(const char *)fileName atLine:(int)lineNumber
 {
     HCStringDescription *description = [HCStringDescription stringDescription];
+    // Make sure matcher has been called before, like assertThat would have done.
+    [matcher matches:arg];
     BOOL result = [matcher matches:arg describingMismatchTo:description];
     if (result)
     {


### PR DESCRIPTION
Matching the collection always worked on the same mutable array instance of
matchers. The second round of matching (for the description) therefore
reported the wrong mismatch.

The tests did not reveal this problem, because the assert method exercised
the matching only once.
