### PR TITLE
Add asynchronous assertThat named assertThatAfter

### DIFF
--- a/Source/Core/Asynchronous/HCAssertThatAfter.h
+++ b/Source/Core/Asynchronous/HCAssertThatAfter.h
@@ -1,0 +1,45 @@
+//
+//  HCAssertThatAfter.h
+//  OCHamcrest
+//
+//  Created by Sergio Padrino on 8/25/13.
+//  Copyright (c) 2013 hamcrest.org. All rights reserved.
+//
+
+#import <objc/objc-api.h>
+
+@protocol HCMatcher;
+
+typedef id (^HCAssertThatAfterActualBlock)();
+
+OBJC_EXPORT void HC_assertThatAfterWithLocation(id testCase, NSTimeInterval maxTime, HCAssertThatAfterActualBlock actualBlock, id<HCMatcher> matcher,
+                                           const char *fileName, int lineNumber);
+
+#define HC_assertThatAfter(maxTime, actualBlock, matcher)  \
+    HC_assertThatAfterWithLocation(self, maxTime, actualBlock, matcher, __FILE__, __LINE__)
+
+#define HC_futureValueOf(actual) ^{ return actual; }
+
+/**
+ assertThatAfter(maxTime, actualBlock, matcher) -
+ Asserts that a value provided by a block will satisfy matcher in less than a given time.
+ 
+ @param maxTime       Max time (in seconds) in which the matcher has to be satisfied.
+ @param actualBlock   A block providing the object to evaluate until timeout or the matcher is satisfied.
+ @param matcher       The matcher to satisfy as the expected condition.
+ 
+ @c assertThatAfter checks several times if the matcher is satisfied before timeout. To evaluate the matcher, the actualBlock will
+ provide updated values of actual. If the matcher is not satisfied after maxTime, an exception is thrown describing the mismatch.
+ An easy way of defining this actualBlock is using the macro futureValueOf(actual), which also improves readability.
+ 
+ In the event of a name clash, don't \#define @c HC_SHORTHAND and use the synonym
+ @c HC_assertThatAfter and HC_futureValueOf instead.
+ 
+ @ingroup integration
+ */
+#ifdef HC_SHORTHAND
+#define assertThatAfter HC_assertThatAfter
+#define futureValueOf HC_futureValueOf
+#endif
+
+

--- a/Source/Core/Asynchronous/HCAssertThatAfter.m
+++ b/Source/Core/Asynchronous/HCAssertThatAfter.m
@@ -1,0 +1,115 @@
+//
+//  HCAssertThatAfter.m
+//  OCHamcrest
+//
+//  Created by Sergio Padrino on 8/25/13.
+//  Copyright (c) 2013 hamcrest.org. All rights reserved.
+//
+
+#import "HCAssertThatAfter.h"
+
+#import "HCStringDescription.h"
+#import "HCMatcher.h"
+
+
+static inline BOOL isLinkedToOCUnit()
+{
+    return NSClassFromString(@"XCTestCase") != Nil || NSClassFromString(@"SenTestCase") != Nil;
+}
+
+/**
+ Create OCUnit failure
+ 
+ With OCUnit's extension to NSException, this is effectively the same as
+ @code
+ [NSException failureInFile: [NSString stringWithUTF8String:fileName]
+ atLine: lineNumber
+ withDescription: description]
+ @endcode
+ except we use an NSInvocation so that OCUnit (SenTestingKit) does not have to be linked.
+ */
+static NSException *createOCUnitException(const char* fileName, int lineNumber, NSString *description)
+{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wundeclared-selector"
+    SEL selector = @selector(failureInFile:atLine:withDescription:);
+#pragma clang diagnostic pop
+    
+    // Description expects a format string, but NSInvocation does not support varargs.
+    // Mask % symbols in the string so they aren't treated as placeholders.
+    description = [description stringByReplacingOccurrencesOfString:@"%"
+                                                         withString:@"%%"];
+    
+    NSMethodSignature *signature = [[NSException class] methodSignatureForSelector:selector];
+    NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];
+    [invocation setTarget:[NSException class]];
+    [invocation setSelector:selector];
+    
+    id fileArg = @(fileName);
+    [invocation setArgument:&fileArg atIndex:2];
+    [invocation setArgument:&lineNumber atIndex:3];
+    [invocation setArgument:&description atIndex:4];
+    
+    [invocation invoke];
+    __unsafe_unretained NSException *result = nil;
+    [invocation getReturnValue:&result];
+    return result;
+}
+
+static NSException *createGenericException(const char *fileName, int lineNumber, NSString *description)
+{
+    NSString *failureReason = [NSString stringWithFormat:@"%s:%d: matcher error: %@",
+                               fileName, lineNumber, description];
+    return [NSException exceptionWithName:@"Hamcrest Error" reason:failureReason userInfo:nil];
+}
+
+static NSException *createAssertThatFailure(const char *fileName, int lineNumber, NSString *description)
+{
+    if (isLinkedToOCUnit())
+        return createOCUnitException(fileName, lineNumber, description);
+    else
+        return createGenericException(fileName, lineNumber, description);
+}
+
+#pragma mark -
+
+// As of 2010-09-09, the iPhone simulator has a bug where you can't catch
+// exceptions when they are thrown across NSInvocation boundaries. (See
+// dmaclach's comment at http://openradar.appspot.com/8081169 ) So instead of
+// using an NSInvocation to call failWithException:assertThatFailure without
+// linking in OCUnit, we simply pretend it exists on NSObject.
+@interface NSObject (HCExceptionBugHack)
+- (void)failWithException:(NSException *)exception;
+@end
+
+void HC_assertThatAfterWithLocation(id testCase, NSTimeInterval maxTime, HCAssertThatAfterActualBlock actualBlock,
+                                    id<HCMatcher> matcher, const char *fileName, int lineNumber)
+{
+    BOOL matches = NO;
+    id actual = nil;
+    NSTimeInterval timeOut = maxTime;
+    NSDate *expiryDate = [NSDate dateWithTimeIntervalSinceNow:timeOut];
+    while(1)
+    {
+        actual = actualBlock();
+        matches = [matcher matches:actual];
+        if(matches || ([(NSDate *)[NSDate date] compare:expiryDate] == NSOrderedDescending)) {
+            break;
+        }
+        [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.01]];
+        OSMemoryBarrier();
+    }
+    
+    if (!matches)
+    {
+        HCStringDescription *description = [HCStringDescription stringDescription];
+        [[[description appendText:@"Expected "]
+          appendDescriptionOf:matcher]
+         appendText:@", but "];
+        [matcher describeMismatchOf:actual to:description];
+        
+        NSException *assertThatFailure = createAssertThatFailure(fileName, lineNumber,
+                                                                 [description description]);
+        [testCase failWithException:assertThatFailure];
+    }
+}

--- a/Source/Core/HCAssertThat.h
+++ b/Source/Core/HCAssertThat.h
@@ -34,6 +34,8 @@ OBJC_EXPORT void HC_assertThatWithLocation(id testCase, id actual, id<HCMatcher>
     
     In the event of a name clash, don't \#define @c HC_SHORTHAND and use the synonym
     @c HC_assertThat instead.
+ 
+    @c assertThat is a specific case of assertThatAfter with timeout 0.
     
     @ingroup integration
  */

--- a/Source/Core/HCAssertThat.m
+++ b/Source/Core/HCAssertThat.m
@@ -9,94 +9,13 @@
 
 #import "HCAssertThat.h"
 
+#import "HCAssertThatAfter.h"
+
 #import "HCStringDescription.h"
 #import "HCMatcher.h"
-
-
-static inline BOOL isLinkedToOCUnit()
-{
-    return NSClassFromString(@"XCTestCase") != Nil || NSClassFromString(@"SenTestCase") != Nil;
-}
-
-/**
-    Create OCUnit failure
-    
-    With OCUnit's extension to NSException, this is effectively the same as
-@code
-[NSException failureInFile: [NSString stringWithUTF8String:fileName]
-                    atLine: lineNumber
-           withDescription: description]
-@endcode
-    except we use an NSInvocation so that OCUnit (SenTestingKit) does not have to be linked.
- */
-static NSException *createOCUnitException(const char* fileName, int lineNumber, NSString *description)
-{
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wundeclared-selector"
-    SEL selector = @selector(failureInFile:atLine:withDescription:);
-#pragma clang diagnostic pop
-
-    // Description expects a format string, but NSInvocation does not support varargs.
-    // Mask % symbols in the string so they aren't treated as placeholders.
-    description = [description stringByReplacingOccurrencesOfString:@"%"
-                                                         withString:@"%%"];
-
-    NSMethodSignature *signature = [[NSException class] methodSignatureForSelector:selector];
-    NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];
-    [invocation setTarget:[NSException class]];
-    [invocation setSelector:selector];
-    
-    id fileArg = @(fileName);
-    [invocation setArgument:&fileArg atIndex:2];
-    [invocation setArgument:&lineNumber atIndex:3];
-    [invocation setArgument:&description atIndex:4];
-    
-    [invocation invoke];
-    __unsafe_unretained NSException *result = nil;
-    [invocation getReturnValue:&result];
-    return result;
-}
-
-static NSException *createGenericException(const char *fileName, int lineNumber, NSString *description)
-{
-    NSString *failureReason = [NSString stringWithFormat:@"%s:%d: matcher error: %@",
-                               fileName, lineNumber, description];
-    return [NSException exceptionWithName:@"Hamcrest Error" reason:failureReason userInfo:nil];
-}
-
-static NSException *createAssertThatFailure(const char *fileName, int lineNumber, NSString *description)
-{
-    if (isLinkedToOCUnit())
-        return createOCUnitException(fileName, lineNumber, description);
-    else
-        return createGenericException(fileName, lineNumber, description);
-}
-
-
-#pragma mark -
-
-// As of 2010-09-09, the iPhone simulator has a bug where you can't catch
-// exceptions when they are thrown across NSInvocation boundaries. (See
-// dmaclach's comment at http://openradar.appspot.com/8081169 ) So instead of
-// using an NSInvocation to call failWithException:assertThatFailure without
-// linking in OCUnit, we simply pretend it exists on NSObject.
-@interface NSObject (HCExceptionBugHack)
-- (void)failWithException:(NSException *)exception;
-@end
 
 void HC_assertThatWithLocation(id testCase, id actual, id<HCMatcher> matcher,
                                            const char *fileName, int lineNumber)
 {
-    if (![matcher matches:actual])
-    {
-        HCStringDescription *description = [HCStringDescription stringDescription];
-        [[[description appendText:@"Expected "]
-                       appendDescriptionOf:matcher]
-                       appendText:@", but "];
-        [matcher describeMismatchOf:actual to:description];
-        
-        NSException *assertThatFailure = createAssertThatFailure(fileName, lineNumber,
-                                                                 [description description]);
-        [testCase failWithException:assertThatFailure];
-    }
+    HC_assertThatAfterWithLocation(testCase, 0, HC_futureValueOf(actual), matcher, fileName, lineNumber);
 }

--- a/Source/OCHamcrest.xcodeproj/project.pbxproj
+++ b/Source/OCHamcrest.xcodeproj/project.pbxproj
@@ -230,6 +230,14 @@
 		088FB0B2136A70B800C191E1 /* HCStringContainsInOrder.m in Sources */ = {isa = PBXBuildFile; fileRef = 088FB0AE136A70B800C191E1 /* HCStringContainsInOrder.m */; };
 		08EE4340165FFE3F006AB8E1 /* HCAssertThat.m in Sources */ = {isa = PBXBuildFile; fileRef = 0876022D13440A83001B439B /* HCAssertThat.m */; };
 		08EE4341165FFE47006AB8E1 /* HCBaseDescription.m in Sources */ = {isa = PBXBuildFile; fileRef = 0876022F13440A83001B439B /* HCBaseDescription.m */; };
+		4021356F17CA7F4A000A23E1 /* MockRun.m in Sources */ = {isa = PBXBuildFile; fileRef = 4021356E17CA7F4A000A23E1 /* MockRun.m */; };
+		4021357017CA7F4A000A23E1 /* MockRun.m in Sources */ = {isa = PBXBuildFile; fileRef = 4021356E17CA7F4A000A23E1 /* MockRun.m */; };
+		4021357317CA82F4000A23E1 /* AssertThatAfterTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 4021357217CA82F4000A23E1 /* AssertThatAfterTest.m */; };
+		4021357417CA82F4000A23E1 /* AssertThatAfterTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 4021357217CA82F4000A23E1 /* AssertThatAfterTest.m */; };
+		4021357817CA831B000A23E1 /* HCAssertThatAfter.h in Headers */ = {isa = PBXBuildFile; fileRef = 4021357617CA831B000A23E1 /* HCAssertThatAfter.h */; };
+		4021357917CA831B000A23E1 /* HCAssertThatAfter.h in Headers */ = {isa = PBXBuildFile; fileRef = 4021357617CA831B000A23E1 /* HCAssertThatAfter.h */; };
+		4021357A17CA831B000A23E1 /* HCAssertThatAfter.m in Sources */ = {isa = PBXBuildFile; fileRef = 4021357717CA831B000A23E1 /* HCAssertThatAfter.m */; };
+		4021357B17CA831B000A23E1 /* HCAssertThatAfter.m in Sources */ = {isa = PBXBuildFile; fileRef = 4021357717CA831B000A23E1 /* HCAssertThatAfter.m */; };
 		5F2773401436F50C00B9683A /* HCConformsToProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 5F27733E1436F50C00B9683A /* HCConformsToProtocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5F2773411436F50C00B9683A /* HCConformsToProtocol.m in Sources */ = {isa = PBXBuildFile; fileRef = 5F27733F1436F50C00B9683A /* HCConformsToProtocol.m */; };
 		5F2773471436FA9D00B9683A /* HCConformsToProtocol.m in Sources */ = {isa = PBXBuildFile; fileRef = 5F27733F1436F50C00B9683A /* HCConformsToProtocol.m */; };
@@ -417,6 +425,11 @@
 		08C7868215843B7200A7FA46 /* MainPage.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MainPage.h; sourceTree = "<group>"; };
 		08C7868315843B7900A7FA46 /* CustomMatchers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CustomMatchers.h; sourceTree = "<group>"; };
 		08F39BAA1711426200745958 /* CHANGES.txt */ = {isa = PBXFileReference; lastKnownFileType = text; name = CHANGES.txt; path = ../CHANGES.txt; sourceTree = "<group>"; };
+		4021356D17CA7F4A000A23E1 /* MockRun.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MockRun.h; sourceTree = "<group>"; };
+		4021356E17CA7F4A000A23E1 /* MockRun.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MockRun.m; sourceTree = "<group>"; };
+		4021357217CA82F4000A23E1 /* AssertThatAfterTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AssertThatAfterTest.m; sourceTree = "<group>"; };
+		4021357617CA831B000A23E1 /* HCAssertThatAfter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HCAssertThatAfter.h; sourceTree = "<group>"; };
+		4021357717CA831B000A23E1 /* HCAssertThatAfter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HCAssertThatAfter.m; sourceTree = "<group>"; };
 		5F27733E1436F50C00B9683A /* HCConformsToProtocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HCConformsToProtocol.h; sourceTree = "<group>"; };
 		5F27733F1436F50C00B9683A /* HCConformsToProtocol.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HCConformsToProtocol.m; sourceTree = "<group>"; };
 		5F2773441436F81000B9683A /* ConformsToProtocolTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ConformsToProtocolTest.m; sourceTree = "<group>"; };
@@ -471,12 +484,15 @@
 		082E7C2813FF676E004A22FE /* Core */ = {
 			isa = PBXGroup;
 			children = (
+				4021357117CA82F4000A23E1 /* Asynchronous */,
 				082E7C2913FF676E004A22FE /* AbstractMatcherTest.h */,
 				082E7C2A13FF676E004A22FE /* AbstractMatcherTest.m */,
 				082E7C2B13FF676E004A22FE /* AssertThatTest.m */,
 				082E7C2C13FF676E004A22FE /* BaseMatcherTest.m */,
 				082E7C2D13FF676E004A22FE /* InvocationMatcherTest.m */,
 				082E7C2E13FF676E004A22FE /* StringDescriptionTest.m */,
+				4021356D17CA7F4A000A23E1 /* MockRun.h */,
+				4021356E17CA7F4A000A23E1 /* MockRun.m */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -576,6 +592,7 @@
 		0876021613440A83001B439B /* Core */ = {
 			isa = PBXGroup;
 			children = (
+				4021357517CA831B000A23E1 /* Asynchronous */,
 				0876022C13440A83001B439B /* HCAssertThat.h */,
 				0876022D13440A83001B439B /* HCAssertThat.m */,
 				0876022E13440A83001B439B /* HCBaseDescription.h */,
@@ -813,6 +830,23 @@
 			name = "Scripts & Docs";
 			sourceTree = "<group>";
 		};
+		4021357117CA82F4000A23E1 /* Asynchronous */ = {
+			isa = PBXGroup;
+			children = (
+				4021357217CA82F4000A23E1 /* AssertThatAfterTest.m */,
+			);
+			path = Asynchronous;
+			sourceTree = "<group>";
+		};
+		4021357517CA831B000A23E1 /* Asynchronous */ = {
+			isa = PBXGroup;
+			children = (
+				4021357617CA831B000A23E1 /* HCAssertThatAfter.h */,
+				4021357717CA831B000A23E1 /* HCAssertThatAfter.m */,
+			);
+			path = Asynchronous;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -820,6 +854,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4021357917CA831B000A23E1 /* HCAssertThatAfter.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -877,6 +912,7 @@
 				5F2773401436F50C00B9683A /* HCConformsToProtocol.h in Headers */,
 				BB33323D0F9D992AE94980EE /* HCIsTypeOf.h in Headers */,
 				0850A4521716624B0019BBE0 /* HCClassMatcher.h in Headers */,
+				4021357817CA831B000A23E1 /* HCAssertThatAfter.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1117,6 +1153,7 @@
 				5F2773471436FA9D00B9683A /* HCConformsToProtocol.m in Sources */,
 				BB3336CE4A9F65ABD486550E /* HCIsTypeOf.m in Sources */,
 				0850A4551716624B0019BBE0 /* HCClassMatcher.m in Sources */,
+				4021357B17CA831B000A23E1 /* HCAssertThatAfter.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1168,6 +1205,8 @@
 				5F2773491436FAA700B9683A /* ConformsToProtocolTest.m in Sources */,
 				BB3330581DF04CB5115BCD11 /* IsTypeOfTest.m in Sources */,
 				0850A44F17165D2A0019BBE0 /* SomeClassAndSubclass.m in Sources */,
+				4021357017CA7F4A000A23E1 /* MockRun.m in Sources */,
+				4021357417CA82F4000A23E1 /* AssertThatAfterTest.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1221,6 +1260,7 @@
 				5F2773411436F50C00B9683A /* HCConformsToProtocol.m in Sources */,
 				BB3330F94E0ADAF09D41A922 /* HCIsTypeOf.m in Sources */,
 				0850A4541716624B0019BBE0 /* HCClassMatcher.m in Sources */,
+				4021357A17CA831B000A23E1 /* HCAssertThatAfter.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1272,6 +1312,8 @@
 				5F2773481436FAA600B9683A /* ConformsToProtocolTest.m in Sources */,
 				BB33303F6D1004392A6EF76A /* IsTypeOfTest.m in Sources */,
 				0850A44E17165D2A0019BBE0 /* SomeClassAndSubclass.m in Sources */,
+				4021356F17CA7F4A000A23E1 /* MockRun.m in Sources */,
+				4021357317CA82F4000A23E1 /* AssertThatAfterTest.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Source/Tests/Core/AssertThatTest.m
+++ b/Source/Tests/Core/AssertThatTest.m
@@ -16,45 +16,7 @@
 
     // Test support
 #import <SenTestingKit/SenTestingKit.h>
-
-
-@interface MockTestRun : SenTestCaseRun
-{
-    // Can't use original attributes because they're declared @private.
-    unsigned int myFailureCount;
-    unsigned int myUnexpectedExceptionCount;
-}
-@end
-
-@implementation MockTestRun
-
-- (void)addException:(NSException *) anException
-{
-    if ([[anException name] isEqualToString:SenTestFailureException])
-        ++myFailureCount;
-    else
-        ++myUnexpectedExceptionCount;
-}
-
-- (unsigned int)failureCount
-{
-    return myFailureCount;
-}
-
-- (unsigned int)unexpectedExceptionCount
-{
-    return myUnexpectedExceptionCount;
-}
-
-- (void)stop
-{
-    // Override to avoid posting notification.
-}
-
-@end
-
-
-#pragma mark -
+#import "MockRun.h"
 
 @interface QuietTest : SenTestCase
 @end

--- a/Source/Tests/Core/Asynchronous/AssertThatAfterTest.m
+++ b/Source/Tests/Core/Asynchronous/AssertThatAfterTest.m
@@ -1,0 +1,199 @@
+//
+//  OCHamcrest - AssertThatAfterTest.m
+//  Copyright 2013 hamcrest.org. All rights reserved.
+//
+//  Created by: Sergio Padrino
+//
+
+// Class under test
+#define HC_SHORTHAND
+#import <OCHamcrest/HCAssertThatAfter.h>
+
+// Collaborators
+#import <OCHamcrest/HCIsEqual.h>
+
+// Test support
+#import <SenTestingKit/SenTestingKit.h>
+#import "MockRun.h"
+
+static NSTimeInterval const TIME_ERROR_MARGIN = 0.1f;
+
+#pragma mark -
+
+@interface AssertThatAfterQuietTest : SenTestCase
+@end
+
+@implementation AssertThatAfterQuietTest
+
+- (Class)testRunClass
+{
+    return [MockTestRun class];
+}
+
+- (void)twoFailingAssertions
+{
+    NSTimeInterval irrelevantMaxTime = 0;
+    assertThatAfter(irrelevantMaxTime, futureValueOf(@"1"), equalTo(@"2"));
+    assertThatAfter(irrelevantMaxTime, futureValueOf(@"3"), equalTo(@"4"));
+}
+
+@end
+
+#pragma mark -
+
+@interface AssertThatAfterTest : SenTestCase
+@end
+
+@implementation AssertThatAfterTest
+
+- (void)testShouldBeSilentOnSuccessfulMatchWithTimeoutZero
+{
+    assertThatAfter(0, futureValueOf(@"foo"), equalTo(@"foo"));
+}
+
+- (void)testShouldBeSilentOnSuccessfulMatchWithTimeoutGreaterThanZero
+{
+    assertThatAfter(5, futureValueOf(@"foo"), equalTo(@"foo"));
+}
+
+- (void)testFailsImmediatelyWithTimeoutZero
+{
+    NSTimeInterval maxTime = 0;
+    NSTimeInterval waitTime = [self timeExecutingBlock:^{
+        @try
+        {
+            [self raiseAfterFailure];
+            assertThatAfter(maxTime, futureValueOf(@"foo"), equalTo(@"bar"));
+        }
+        @catch (NSException *exception)
+        {
+            return;
+        }
+        
+        STFail(@"should have failed");
+    }];
+    
+    STAssertEqualsWithAccuracy(waitTime, maxTime, TIME_ERROR_MARGIN, @"Assert should have failed immediately");
+}
+
+- (void)testFailsAfterTimeoutGreaterThanZero
+{
+    NSTimeInterval maxTime = 0.2;
+    NSTimeInterval waitTime = [self timeExecutingBlock:^{
+        @try
+        {
+            [self raiseAfterFailure];
+            assertThatAfter(maxTime, futureValueOf(@"foo"), equalTo(@"bar"));
+        }
+        @catch (NSException *exception)
+        {
+            return;
+        }
+        
+        STFail(@"should have failed");
+    }];
+    
+    STAssertEqualsWithAccuracy(waitTime, maxTime, TIME_ERROR_MARGIN, @"Assert should have failed after %f seconds", maxTime);
+}
+
+- (void)testAssertWithTimeoutGreaterThanZeroShouldSucceedNotImmediatelyButBeforeTimeout
+{
+    NSTimeInterval maxTime = 1.0;
+    NSTimeInterval succeedTime = 0.2;
+
+    __block NSString *futureBar = @"foo";
+
+    dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(succeedTime * NSEC_PER_SEC));
+    dispatch_after(popTime, dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^(void){
+        futureBar = @"bar";
+    });
+
+    NSTimeInterval waitTime = [self timeExecutingBlock:^{
+        @try
+        {
+            [self raiseAfterFailure];
+            assertThatAfter(maxTime, futureValueOf(futureBar), equalTo(@"bar"));
+        }
+        @catch (NSException *exception)
+        {
+            STFail(@"should have succeeded");
+        }
+    }];
+
+    STAssertEqualsWithAccuracy(waitTime, succeedTime, TIME_ERROR_MARGIN, @"Assert should have succeeded in approximately %f seconds", succeedTime);
+}
+
+- (NSTimeInterval)timeExecutingBlock:(void (^)())block
+{
+    NSDate *initialDate = [NSDate date];
+    
+    block();
+    
+    NSTimeInterval waitTime = -[initialDate timeIntervalSinceNow];
+    
+    return waitTime;
+}
+
+- (void)testAssertionErrorShouldDescribeExpectedAndActual
+{
+    NSString *expected = @"EXPECTED";
+    NSString *actual = @"ACTUAL";
+    NSString *expectedMessage = @"Expected \"EXPECTED\", but was \"ACTUAL\"";
+    NSTimeInterval irrelevantMaxTime = 0;
+    
+    @try
+    {
+        [self raiseAfterFailure];
+        assertThatAfter(irrelevantMaxTime, futureValueOf(actual), equalTo(expected));
+    }
+    @catch (NSException* exception)
+    {
+        STAssertTrue([[exception reason] rangeOfString:expectedMessage].location != NSNotFound, nil);
+        return;
+    }
+    STFail(@"should have failed");
+}
+
+- (void)testAssertionErrorShouldCorrectlyDescribeStringsWithPercentSymbols
+{
+    NSString *expected = @"%s";
+    NSString *actual = @"%d";
+    NSString *expectedMessage = @"Expected \"%s\", but was \"%d\"";
+    NSTimeInterval irrelevantMaxTime = 0;
+
+    @try
+    {
+        [self raiseAfterFailure];
+        assertThatAfter(irrelevantMaxTime, futureValueOf(actual), equalTo(expected));
+    }
+    @catch (NSException* exception)
+    {
+        STAssertTrue([[exception reason] rangeOfString:expectedMessage].location != NSNotFound, nil);
+        return;
+    }
+    STFail(@"should have failed");
+}
+
+- (void)testAssertionRecordingAllErrors
+{
+    AssertThatAfterQuietTest *testCase = [AssertThatAfterQuietTest testCaseWithSelector:@selector(twoFailingAssertions)];
+    [testCase continueAfterFailure];    // Default behavior of OCUnit
+    
+    MockTestRun *testRun = (MockTestRun *)[testCase run];
+    
+    STAssertEquals([testRun failureCount], 2U, nil);
+    STAssertEquals([testRun unexpectedExceptionCount], 0U, nil);
+}
+
+- (void)testAssertionStoppingAtFirstError
+{
+    AssertThatAfterQuietTest *testCase = [AssertThatAfterQuietTest testCaseWithSelector:@selector(twoFailingAssertions)];
+    [testCase raiseAfterFailure];       // Change behavior
+    
+    MockTestRun *testRun = (MockTestRun *)[testCase run];
+    
+    STAssertEquals([testRun failureCount], 1U, nil);
+    STAssertEquals([testRun unexpectedExceptionCount], 0U, nil);
+}
+
+@end

--- a/Source/Tests/Core/MockRun.h
+++ b/Source/Tests/Core/MockRun.h
@@ -1,0 +1,17 @@
+//
+//  MockRun.h
+//  OCHamcrest
+//
+//  Created by Sergio Padrino on 8/25/13.
+//  Copyright (c) 2013 hamcrest.org. All rights reserved.
+//
+
+#import <SenTestingKit/SenTestingKit.h>
+
+@interface MockTestRun : SenTestCaseRun
+{
+    // Can't use original attributes because they're declared @private.
+    unsigned int myFailureCount;
+    unsigned int myUnexpectedExceptionCount;
+}
+@end

--- a/Source/Tests/Core/MockRun.m
+++ b/Source/Tests/Core/MockRun.m
@@ -1,0 +1,36 @@
+//
+//  MockRun.m
+//  OCHamcrest
+//
+//  Created by Sergio Padrino on 8/25/13.
+//  Copyright (c) 2013 hamcrest.org. All rights reserved.
+//
+
+#import "MockRun.h"
+
+@implementation MockTestRun
+
+- (void)addException:(NSException *) anException
+{
+    if ([[anException name] isEqualToString:SenTestFailureException])
+        ++myFailureCount;
+    else
+        ++myUnexpectedExceptionCount;
+}
+
+- (unsigned int)failureCount
+{
+    return myFailureCount;
+}
+
+- (unsigned int)unexpectedExceptionCount
+{
+    return myUnexpectedExceptionCount;
+}
+
+- (void)stop
+{
+    // Override to avoid posting notification.
+}
+
+@end


### PR DESCRIPTION
Hi!

I just added some convenience assert statement for testing asynchronous code easily and without losing readability. The usage is like this:

``` objective-c
assertThatAfter(5, futureValueOf(self.someString), is(equalTo(@"expected")));
```

This checks several times for this string to be @"expected" before timing out after 5 seconds.

The implementation is based in the one used in expecta (https://github.com/specta/expecta/blob/master/src/EXPExpect.m method applyMatcher:to:).

With this in mind, I changed the original assertThat implementation to relay on this one with a timeout of 0 seconds. Of course unit tests have been added and everything is green :+1: 

If you like it, feel free to accept this pull request. If you need me to change something before merging, just tell me and I'll do my best :)

Thank you!
