### PR TITLE
Implementation for willAssertThat for asynchronous matchers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,28 @@ The last form is allowed since ``is`` wraps non-matcher arguments with
 shortcuts, wrapping non-matcher arguments in ``equalTo``.
 
 
+Asynchronous matchers
+=====================
+
+Besides the normal ``assertThat`` function OCHamcrest provides
+``willAssertThat`` function. This function waits for a short period of time
+evaluating the matcher until it satisfied, or a timeout occurs.
+
+```obj-c
+__block Biscuit* theBiscuit = nil;
+[Biscuit biscuitNamed:@"Ginger" withCompletion:^(Biscuit *biscuit){
+  theBiscuit = biscuit;
+}];
+Biscuit* myBiscuit = [Biscuit biscuitNamed:@"Ginger"];
+willAssertThat(theBiscuit, equalTo(myBiscuit));
+```
+
+Default timeout is 1 second. You can change the default timeout calling
+``HC_setWillDefaultTimeout(yourTimeout)`` where ``yourTimeout`` is your
+desidered timeout in seconds. You can recover the actual timeout using
+``HC_willDefaultTimeout``. These two functions do not have equivalents without
+the namespace even if ``HC_SHORTHAND`` is defined.
+
 Writing custom matchers
 =======================
 

--- a/Source/Core/HCAssertThat.h
+++ b/Source/Core/HCAssertThat.h
@@ -40,3 +40,49 @@ OBJC_EXPORT void HC_assertThatWithLocation(id testCase, id actual, id<HCMatcher>
 #ifdef HC_SHORTHAND
     #define assertThat HC_assertThat
 #endif
+
+
+OBJC_EXPORT void HC_willAssertThatWithLocation(id testCase, id (^actualBlock)(void), id<HCMatcher> matcher,
+                                               const char *fileName, int lineNumber);
+
+#define HC_willAssertThat(actual, matcher)  \
+    HC_willAssertThatWithLocation(self, ^{ return (id)(actual); }, matcher, __FILE__, __LINE__)
+
+/**
+    willAssertThat(actual, matcher) -
+    Asserts that the actual value satifies matcher now, or some time in the near future.
+
+    @param actual   The object to evaluate as the actual value.
+    @param matcher  The matcher to satisfy as the expected condition.
+
+    @c willAssertThat works as @c assertThat, but it will also wait up to
+    @c HC_willDefaultTimeout seconds for actual to satisfy the matcher. If after
+    that time the matcher is still not satisfied the assertion will fail.
+
+    Be aware that actual will be captured in a block and evaluated repeatedly until
+    it satisfy the matcher or the timeout has occurred.
+
+    In the event of a name clash, don't \#define @c HC_SHORTHAND and use the synonym
+    @c HC_willAssertThat instead.
+
+    @ingroup integration
+ */
+#ifdef HC_SHORTHAND
+    #define willAssertThat HC_willAssertThat
+#endif
+
+/**
+    Retrieves the default timeout used by @c willAssertThat.
+
+    The default value is 1 second.
+
+    @ingroup integration
+ */
+OBJC_EXPORT NSTimeInterval HC_willDefaultTimeout(void);
+
+/**
+    Sets the default timeout used by @c willAssertThat.
+
+    @ingroup integration
+ */
+OBJC_EXPORT void HC_setWillDefaultTimeout(NSTimeInterval defaultTimeout);

--- a/Source/MainPage.h
+++ b/Source/MainPage.h
@@ -17,6 +17,7 @@
     @li @ref firsttest
     @li @ref predefined
     @li @ref sugar
+    @li @ref async
     @li @ref custom
     @li @ref resources
 
@@ -201,6 +202,27 @@ assertThat(theBiscuit, equalTo(myBiscuit));
 assertThat(theBiscuit, is(equalTo(myBiscuit)));
 assertThat(theBiscuit, is(myBiscuit));
     @endcode
+
+
+    @section async Asynchronous matchers
+
+    Besides the normal @ref assertThat function OCHamcrest provides @ref willAssertThat function.
+    This function waits for a short period of time evaluating the matcher until it satisfied, or
+    a timeout occurs.
+
+    @code
+__block Biscuit* theBiscuit = nil;
+[Biscuit biscuitNamed:@"Ginger" withCompletion:^(Biscuit *biscuit){
+  theBiscuit = biscuit;
+}];
+Biscuit* myBiscuit = [Biscuit biscuitNamed:@"Ginger"];
+willAssertThat(theBiscuit, equalTo(myBiscuit));
+@endcode
+
+    Default timeout is 1 second. You can change the default timeout calling
+    @ref HC_setWillDefaultTimeout. You can recover the actual timeout using
+    @ref HC_willDefaultTimeout. These two functions do not have equivalents without
+    the namespace even if @c HC_SHORTHAND is defined.
 
 
     @section custom Writing custom matchers


### PR DESCRIPTION
willAssertThat will keep evaluating the provided expression until
the matcher is satisfied or a timeout occurs. This allows test to
be much more expressive and simple.
