### PR TITLE
Fixes isNot not asking for the sub matcher's mismatch description

### DIFF
--- a/Source/Library/Logical/HCIsNot.m
+++ b/Source/Library/Logical/HCIsNot.m
@@ -38,6 +38,10 @@
     [[description appendText:@"not "] appendDescriptionOf:matcher];
 }
 
+- (void)describeMismatchOf:(id)item to:(id<HCDescription>)mismatchDescription
+{
+    [matcher describeMismatchOf:item to:mismatchDescription];
+}
 @end
 
 

--- a/Source/Tests/Logical/IsNotTest.m
+++ b/Source/Tests/Logical/IsNotTest.m
@@ -13,6 +13,7 @@
 
     // Collaborators
 #import <OCHamcrest/HCIsEqual.h>
+#import <OCHamcrest/HCHasCount.h>
 
     // Test support
 #import "AbstractMatcherTest.h"
@@ -53,6 +54,13 @@
 - (void)testMismatchDescriptionShowsActualArgument
 {
     assertMismatchDescription(@"was \"A\"", isNot(@"A"), @"A");
+}
+
+- (void)testMismatchDescriptionShowsActualSubMatcherDescription
+{
+    NSArray *item = @[@"A", @"B"];
+    NSString *expected = [NSString stringWithFormat:@"was count of <2> with <%@>", item];
+    assertMismatchDescription(expected, isNot(hasCountOf(item.count)), item);
 }
 
 - (void)testDescribeMismatch


### PR DESCRIPTION
It was just printing objects description.
