### PR TITLE
Drop 64 bit arch to support deployment target 5.0.0

### DIFF
--- a/Source/OCHamcrest.xcodeproj/project.pbxproj
+++ b/Source/OCHamcrest.xcodeproj/project.pbxproj
@@ -1329,7 +1329,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
+				ARCHS = "$(ARCHS_STANDARD)";
 				CLANG_ENABLE_OBJC_ARC = YES;
 				DSTROOT = /tmp/libochamcrest.dst;
 				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
@@ -1344,7 +1344,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
+				ARCHS = "$(ARCHS_STANDARD)";
 				CLANG_ENABLE_OBJC_ARC = YES;
 				DSTROOT = /tmp/libochamcrest.dst;
 				IPHONEOS_DEPLOYMENT_TARGET = 5.0;


### PR DESCRIPTION
Quick fix for https://github.com/hamcrest/OCHamcrest/issues/44 :
- Drops 64 bits arch so MakeDistribution.sh can build the library.
