### PR TITLE
Added tvos support to podspec

### DIFF
--- a/OCHamcrest.podspec
+++ b/OCHamcrest.podspec
@@ -31,6 +31,7 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = '6.0'
   s.osx.deployment_target = '10.8'
+  s.tvos.deployment_target = '9.0'
   s.source = { :git => 'https://github.com/hamcrest/OCHamcrest.git', :tag => 'v5.0.0' }
   s.source_files = 'Source/OCHamcrest.h', 'Source/Core/**/*.{h,m}', 'Source/Library/**/*.{h,m}'
   s.private_header_files = 'Source/Core/Helpers/NSInvocation+OCHamcrest.h', 'Source/Core/Helpers/ReturnValueGetters/*.h', 'Source/Core/Helpers/TestFailureReporters/HCGenericTestFailureReporter.h', 'Source/Core/Helpers/TestFailureReporters/HCSenTestFailureReporter.h', 'Source/Core/Helpers/TestFailureReporters/HCXCTestFailureReporter.h'


### PR DESCRIPTION
I'm trying to integrate some unit tests written for an iOS framework into an identical test bundle for a tvOS version of the framework, but OCHamcrest as is doesn't support tvos according to the podspec. When I manually added the deployment target to the podspec and integrated this version with my library, everything worked and my unit tests with OCHamcrest ran perfectly fine against the tvos framework.

If there's anything I may have missed here, let me know!