### PR TITLE
Remove superfluous semicolon.

### DIFF
--- a/Source/Core/Helpers/TestFailureReporters/HCGenericTestFailureReporter.m
+++ b/Source/Core/Helpers/TestFailureReporters/HCGenericTestFailureReporter.m
@@ -13,7 +13,7 @@
     return YES;
 }
 
-- (void)executeHandlingOfFailure:(HCTestFailure *)failure;
+- (void)executeHandlingOfFailure:(HCTestFailure *)failure
 {
     NSException *exception = [self createExceptionForFailure:failure];
     [exception raise];


### PR DESCRIPTION
Remove a superfluous semicolon in the implementation of the method
-[HCGenericTestFailureReporter executeHandlingOfFailure:] causing
the a warning when building with -Wsemicolon-before-method-body.

Fixes issue #75.