### PR TITLE
Don't use `NSDate` for timeouts

### DIFF
--- a/Source/Core/HCAssertThat.m
+++ b/Source/Core/HCAssertThat.m
@@ -10,6 +10,7 @@
 #import "HCTestFailureReporterChain.h"
 #import <libkern/OSAtomic.h>
 
+typedef void (^HCRunloopObserverBlock)(CFRunLoopObserverRef, CFRunLoopActivity);
 
 static void reportMismatch(id testCase, id actual, id <HCMatcher> matcher,
                            char const *fileName, int lineNumber)
@@ -33,17 +34,31 @@ void HC_assertWithTimeoutAndLocation(id testCase, NSTimeInterval timeout,
         HCFutureValue actualBlock, id <HCMatcher> matcher,
         const char *fileName, int lineNumber)
 {
-    BOOL match;
-    id actual;
-    NSDate *expiryDate = [NSDate dateWithTimeIntervalSinceNow:timeout];
-    while (1)
-    {
-        actual = actualBlock();
-        match = [matcher matches:actual];
-        if (match || ([[NSDate date] compare:expiryDate] == NSOrderedDescending))
-            break;
-        [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.01]];
-        OSMemoryBarrier();
+    // run immediately
+    __block id actual = actualBlock();
+    __block BOOL match = [matcher matches:actual];
+    
+    // if not already matched, pump the runloop until matched
+    if (!match) {
+        HCRunloopObserverBlock pump = ^(CFRunLoopObserverRef observer, CFRunLoopActivity activity) {
+            assert(!match); // runloop should have exited if match occurred
+            actual = actualBlock();
+            match = [matcher matches:actual];
+            if (match) {
+                CFRunLoopStop(CFRunLoopGetCurrent());
+            } else {
+                CFRunLoopWakeUp(CFRunLoopGetCurrent());
+            }
+        };
+        
+        // set up runloop observer and wait stop call or timeout
+        CFRunLoopObserverRef observer = CFRunLoopObserverCreateWithHandler(NULL, kCFRunLoopBeforeWaiting, YES, 0, pump);
+        CFRunLoopAddObserver(CFRunLoopGetCurrent(), observer, kCFRunLoopDefaultMode);
+        CFRunLoopRunInMode(kCFRunLoopDefaultMode, timeout, false);
+        
+        // remove observer
+        CFRunLoopRemoveObserver(CFRunLoopGetCurrent(), observer, kCFRunLoopDefaultMode);
+        CFRelease(observer);
     }
 
     if (!match)


### PR DESCRIPTION
Using `NSDate` for timeouts can be dangerous and lead to weird time-sync problems. Because `NSDate` is based off of system time, it's subject to adjustments (skew, NTP, leap seconds), which can affect the timeouts if the adjustment is large enough.

I converted the while-loop-based implementation to one that uses a runloop observer. The condition will now be tested on every pump of the runloop instead of checking after a predefined delay. [This article](http://bou.io/CTTRunLoopRunUntil.html) was an enlightening read on the subject.

Consequently, when testing this functionality, the test code now also uses `mach` time instead of system time to avoid this same problem from the other end (as well as taking a more precise measurement).