### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/Cocoanetics-Ruby/README.md
+++ b/Cocoanetics-Ruby/README.md
@@ -3,7 +3,7 @@ Cocoanetics Ruby
 
 Collection of my Ruby Scripts
 
-###Coveralls.rb 
+### Coveralls.rb 
 
 This script finds all **.gcda** files unterneath the current user's DerivedData folder. Since you get a fresh VM every time Travis-CI builds those should be the ones that you also want to submit.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
