### PR TITLE
Added the Cartfile.project that is used by the carthage+NSOperation project.

### DIFF
--- a/Cartfile.project
+++ b/Cartfile.project
@@ -1,0 +1,19 @@
+OCHamcrest-watchOS:
+  project: Source/OCHamcrest.xcodeproj
+  sdks:
+  - watchsimulator
+  - watchos
+OCHamcrest-iOS:
+  project: Source/OCHamcrest.xcodeproj
+  sdks:
+  - iphonesimulator
+  - iphoneos
+OCHamcrest:
+  project: Source/OCHamcrest.xcodeproj
+  sdks:
+  - macosx
+OCHamcrest-tvOS:
+  project: Source/OCHamcrest.xcodeproj
+  sdks:
+  - appletvos
+  - appletvsimulator


### PR DESCRIPTION
I use the carthage+NSOperation fork that has much better caching then the original carthage and reduces build times on my CI a lot.
For the cache to work this Cartfile.project file needs to be present, otherwise the project always gets rebuild.
See https://github.com/nsoperations/Carthage for further details.