### PR TITLE
added support for Swift Package Manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ build/
 project.xcworkspace/
 xcuserdata/
 compile_commands.json
+.swiftpm
+.build

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,38 @@
+// swift-tools-version:5.3
+import PackageDescription
+
+let package = Package(
+    name: "OCHamcrest",
+    platforms: [
+        .macOS(.v10_10),
+        .iOS(.v9),
+        .tvOS(.v9),
+        .watchOS(.v2)
+    ],
+    products: [
+        .library(
+            name: "OCHamcrest",
+            targets: ["OCHamcrest"]
+        ),
+    ],
+    targets: [
+        .target(
+            name: "OCHamcrest",
+            path: "Source",
+            exclude: [
+                "Tests",
+                "Tests-Info.plist",
+                "MakeDistribution.sh",
+                "makeXCFramework.sh",
+                "OCHamcrest-Info.plist",
+                "XcodeWarnings.xcconfig",
+            ],
+            publicHeadersPath: "include",
+            cSettings: [
+                CSetting.headerSearchPath("./Core/Helpers"),
+                CSetting.headerSearchPath("./Core/Helpers/ReturnValueGetters"),
+                CSetting.headerSearchPath("./Core/Helpers/TestFailureReporters"),
+            ]
+        ),
+    ]
+)

--- a/Source/Core/Helpers/HCWrapInMatcher.m
+++ b/Source/Core/Helpers/HCWrapInMatcher.m
@@ -3,7 +3,7 @@
 
 #import "HCWrapInMatcher.h"
 
-#import "HCIsEqual.h"
+#import <OCHamcrest/HCIsEqual.h>
 
 
 _Nullable id <HCMatcher> HCWrapInMatcher(_Nullable id matcherOrValue)

--- a/Source/Library/Collection/HCHasCount.m
+++ b/Source/Library/Collection/HCHasCount.m
@@ -3,7 +3,7 @@
 
 #import "HCHasCount.h"
 
-#import "HCIsEqual.h"
+#import <OCHamcrest/HCIsEqual.h>
 
 
 @interface HCHasCount ()

--- a/Source/Library/Collection/HCIsCollectionContaining.m
+++ b/Source/Library/Collection/HCIsCollectionContaining.m
@@ -3,7 +3,7 @@
 
 #import "HCIsCollectionContaining.h"
 
-#import "HCAllOf.h"
+#import <OCHamcrest/HCAllOf.h>
 #import "HCCollect.h"
 #import "HCRequireNonNilObject.h"
 #import "HCWrapInMatcher.h"

--- a/Source/Library/Collection/HCIsCollectionOnlyContaining.m
+++ b/Source/Library/Collection/HCIsCollectionOnlyContaining.m
@@ -3,7 +3,7 @@
 
 #import "HCIsCollectionOnlyContaining.h"
 
-#import "HCAnyOf.h"
+#import <OCHamcrest/HCAnyOf.h>
 #import "HCCollect.h"
 
 

--- a/Source/Library/Collection/HCIsEmptyCollection.m
+++ b/Source/Library/Collection/HCIsEmptyCollection.m
@@ -3,7 +3,7 @@
 
 #import "HCIsEmptyCollection.h"
 
-#import "HCIsEqual.h"
+#import <OCHamcrest/HCIsEqual.h>
 
 
 @implementation HCIsEmptyCollection

--- a/Source/Library/Number/HCIsEqualToNumber.m
+++ b/Source/Library/Number/HCIsEqualToNumber.m
@@ -3,7 +3,7 @@
 
 #import "HCIsEqualToNumber.h"
 
-#import "HCIsEqual.h"
+#import <OCHamcrest/HCIsEqual.h>
 
 
 FOUNDATION_EXPORT id HC_equalToChar(char value)

--- a/Source/Library/Number/HCNumberAssert.m
+++ b/Source/Library/Number/HCNumberAssert.m
@@ -3,7 +3,7 @@
 
 #import "HCNumberAssert.h"
 
-#import "HCAssertThat.h"
+#import <OCHamcrest/HCAssertThat.h>
 
 
 FOUNDATION_EXPORT void HC_assertThatBoolWithLocation(id testCase, BOOL actual,

--- a/Source/Library/Object/HCIsNil.m
+++ b/Source/Library/Object/HCIsNil.m
@@ -3,7 +3,7 @@
 
 #import "HCIsNil.h"
 
-#import "HCIsNot.h"
+#import <OCHamcrest/HCIsNot.h>
 
 
 @implementation HCIsNil

--- a/Source/include/OCHamcrest/HCAllOf.h
+++ b/Source/include/OCHamcrest/HCAllOf.h
@@ -1,0 +1,1 @@
+../../Library/Logical/HCAllOf.h

--- a/Source/include/OCHamcrest/HCAnyOf.h
+++ b/Source/include/OCHamcrest/HCAnyOf.h
@@ -1,0 +1,1 @@
+../../Library/Logical/HCAnyOf.h

--- a/Source/include/OCHamcrest/HCArgumentCaptor.h
+++ b/Source/include/OCHamcrest/HCArgumentCaptor.h
@@ -1,0 +1,1 @@
+../../Library/Object/HCArgumentCaptor.h

--- a/Source/include/OCHamcrest/HCAssertThat.h
+++ b/Source/include/OCHamcrest/HCAssertThat.h
@@ -1,0 +1,1 @@
+../../Core/HCAssertThat.h

--- a/Source/include/OCHamcrest/HCBaseDescription.h
+++ b/Source/include/OCHamcrest/HCBaseDescription.h
@@ -1,0 +1,1 @@
+../../Core/HCBaseDescription.h

--- a/Source/include/OCHamcrest/HCBaseMatcher.h
+++ b/Source/include/OCHamcrest/HCBaseMatcher.h
@@ -1,0 +1,1 @@
+../../Core/HCBaseMatcher.h

--- a/Source/include/OCHamcrest/HCClassMatcher.h
+++ b/Source/include/OCHamcrest/HCClassMatcher.h
@@ -1,0 +1,1 @@
+../../Library/Object/HCClassMatcher.h

--- a/Source/include/OCHamcrest/HCCollect.h
+++ b/Source/include/OCHamcrest/HCCollect.h
@@ -1,0 +1,1 @@
+../../Core/Helpers/HCCollect.h

--- a/Source/include/OCHamcrest/HCConformsToProtocol.h
+++ b/Source/include/OCHamcrest/HCConformsToProtocol.h
@@ -1,0 +1,1 @@
+../../Library/Object/HCConformsToProtocol.h

--- a/Source/include/OCHamcrest/HCDescribedAs.h
+++ b/Source/include/OCHamcrest/HCDescribedAs.h
@@ -1,0 +1,1 @@
+../../Library/Decorator/HCDescribedAs.h

--- a/Source/include/OCHamcrest/HCDescription.h
+++ b/Source/include/OCHamcrest/HCDescription.h
@@ -1,0 +1,1 @@
+../../Core/HCDescription.h

--- a/Source/include/OCHamcrest/HCDiagnosingMatcher.h
+++ b/Source/include/OCHamcrest/HCDiagnosingMatcher.h
@@ -1,0 +1,1 @@
+../../Core/HCDiagnosingMatcher.h

--- a/Source/include/OCHamcrest/HCEvery.h
+++ b/Source/include/OCHamcrest/HCEvery.h
@@ -1,0 +1,1 @@
+../../Library/Collection/HCEvery.h

--- a/Source/include/OCHamcrest/HCHasCount.h
+++ b/Source/include/OCHamcrest/HCHasCount.h
@@ -1,0 +1,1 @@
+../../Library/Collection/HCHasCount.h

--- a/Source/include/OCHamcrest/HCHasDescription.h
+++ b/Source/include/OCHamcrest/HCHasDescription.h
@@ -1,0 +1,1 @@
+../../Library/Object/HCHasDescription.h

--- a/Source/include/OCHamcrest/HCHasProperty.h
+++ b/Source/include/OCHamcrest/HCHasProperty.h
@@ -1,0 +1,1 @@
+../../Library/Object/HCHasProperty.h

--- a/Source/include/OCHamcrest/HCInvocationMatcher.h
+++ b/Source/include/OCHamcrest/HCInvocationMatcher.h
@@ -1,0 +1,1 @@
+../../Core/Helpers/HCInvocationMatcher.h

--- a/Source/include/OCHamcrest/HCIs.h
+++ b/Source/include/OCHamcrest/HCIs.h
@@ -1,0 +1,1 @@
+../../Library/Decorator/HCIs.h

--- a/Source/include/OCHamcrest/HCIsAnything.h
+++ b/Source/include/OCHamcrest/HCIsAnything.h
@@ -1,0 +1,1 @@
+../../Library/Logical/HCIsAnything.h

--- a/Source/include/OCHamcrest/HCIsCloseTo.h
+++ b/Source/include/OCHamcrest/HCIsCloseTo.h
@@ -1,0 +1,1 @@
+../../Library/Number/HCIsCloseTo.h

--- a/Source/include/OCHamcrest/HCIsCollectionContaining.h
+++ b/Source/include/OCHamcrest/HCIsCollectionContaining.h
@@ -1,0 +1,1 @@
+../../Library/Collection/HCIsCollectionContaining.h

--- a/Source/include/OCHamcrest/HCIsCollectionContainingInAnyOrder.h
+++ b/Source/include/OCHamcrest/HCIsCollectionContainingInAnyOrder.h
@@ -1,0 +1,1 @@
+../../Library/Collection/HCIsCollectionContainingInAnyOrder.h

--- a/Source/include/OCHamcrest/HCIsCollectionContainingInOrder.h
+++ b/Source/include/OCHamcrest/HCIsCollectionContainingInOrder.h
@@ -1,0 +1,1 @@
+../../Library/Collection/HCIsCollectionContainingInOrder.h

--- a/Source/include/OCHamcrest/HCIsCollectionContainingInRelativeOrder.h
+++ b/Source/include/OCHamcrest/HCIsCollectionContainingInRelativeOrder.h
@@ -1,0 +1,1 @@
+../../Library/Collection/HCIsCollectionContainingInRelativeOrder.h

--- a/Source/include/OCHamcrest/HCIsCollectionOnlyContaining.h
+++ b/Source/include/OCHamcrest/HCIsCollectionOnlyContaining.h
@@ -1,0 +1,1 @@
+../../Library/Collection/HCIsCollectionOnlyContaining.h

--- a/Source/include/OCHamcrest/HCIsDictionaryContaining.h
+++ b/Source/include/OCHamcrest/HCIsDictionaryContaining.h
@@ -1,0 +1,1 @@
+../../Library/Collection/HCIsDictionaryContaining.h

--- a/Source/include/OCHamcrest/HCIsDictionaryContainingEntries.h
+++ b/Source/include/OCHamcrest/HCIsDictionaryContainingEntries.h
@@ -1,0 +1,1 @@
+../../Library/Collection/HCIsDictionaryContainingEntries.h

--- a/Source/include/OCHamcrest/HCIsDictionaryContainingKey.h
+++ b/Source/include/OCHamcrest/HCIsDictionaryContainingKey.h
@@ -1,0 +1,1 @@
+../../Library/Collection/HCIsDictionaryContainingKey.h

--- a/Source/include/OCHamcrest/HCIsDictionaryContainingValue.h
+++ b/Source/include/OCHamcrest/HCIsDictionaryContainingValue.h
@@ -1,0 +1,1 @@
+../../Library/Collection/HCIsDictionaryContainingValue.h

--- a/Source/include/OCHamcrest/HCIsEmptyCollection.h
+++ b/Source/include/OCHamcrest/HCIsEmptyCollection.h
@@ -1,0 +1,1 @@
+../../Library/Collection/HCIsEmptyCollection.h

--- a/Source/include/OCHamcrest/HCIsEqual.h
+++ b/Source/include/OCHamcrest/HCIsEqual.h
@@ -1,0 +1,1 @@
+../../Library/Object/HCIsEqual.h

--- a/Source/include/OCHamcrest/HCIsEqualCompressingWhiteSpace.h
+++ b/Source/include/OCHamcrest/HCIsEqualCompressingWhiteSpace.h
@@ -1,0 +1,1 @@
+../../Library/Text/HCIsEqualCompressingWhiteSpace.h

--- a/Source/include/OCHamcrest/HCIsEqualIgnoringCase.h
+++ b/Source/include/OCHamcrest/HCIsEqualIgnoringCase.h
@@ -1,0 +1,1 @@
+../../Library/Text/HCIsEqualIgnoringCase.h

--- a/Source/include/OCHamcrest/HCIsEqualToNumber.h
+++ b/Source/include/OCHamcrest/HCIsEqualToNumber.h
@@ -1,0 +1,1 @@
+../../Library/Number/HCIsEqualToNumber.h

--- a/Source/include/OCHamcrest/HCIsIn.h
+++ b/Source/include/OCHamcrest/HCIsIn.h
@@ -1,0 +1,1 @@
+../../Library/Collection/HCIsIn.h

--- a/Source/include/OCHamcrest/HCIsInstanceOf.h
+++ b/Source/include/OCHamcrest/HCIsInstanceOf.h
@@ -1,0 +1,1 @@
+../../Library/Object/HCIsInstanceOf.h

--- a/Source/include/OCHamcrest/HCIsNil.h
+++ b/Source/include/OCHamcrest/HCIsNil.h
@@ -1,0 +1,1 @@
+../../Library/Object/HCIsNil.h

--- a/Source/include/OCHamcrest/HCIsNot.h
+++ b/Source/include/OCHamcrest/HCIsNot.h
@@ -1,0 +1,1 @@
+../../Library/Logical/HCIsNot.h

--- a/Source/include/OCHamcrest/HCIsSame.h
+++ b/Source/include/OCHamcrest/HCIsSame.h
@@ -1,0 +1,1 @@
+../../Library/Object/HCIsSame.h

--- a/Source/include/OCHamcrest/HCIsTrueFalse.h
+++ b/Source/include/OCHamcrest/HCIsTrueFalse.h
@@ -1,0 +1,1 @@
+../../Library/Number/HCIsTrueFalse.h

--- a/Source/include/OCHamcrest/HCIsTypeOf.h
+++ b/Source/include/OCHamcrest/HCIsTypeOf.h
@@ -1,0 +1,1 @@
+../../Library/Object/HCIsTypeOf.h

--- a/Source/include/OCHamcrest/HCMatcher.h
+++ b/Source/include/OCHamcrest/HCMatcher.h
@@ -1,0 +1,1 @@
+../../Core/HCMatcher.h

--- a/Source/include/OCHamcrest/HCNumberAssert.h
+++ b/Source/include/OCHamcrest/HCNumberAssert.h
@@ -1,0 +1,1 @@
+../../Library/Number/HCNumberAssert.h

--- a/Source/include/OCHamcrest/HCOrderingComparison.h
+++ b/Source/include/OCHamcrest/HCOrderingComparison.h
@@ -1,0 +1,1 @@
+../../Library/Number/HCOrderingComparison.h

--- a/Source/include/OCHamcrest/HCRequireNonNilObject.h
+++ b/Source/include/OCHamcrest/HCRequireNonNilObject.h
@@ -1,0 +1,1 @@
+../../Core/Helpers/HCRequireNonNilObject.h

--- a/Source/include/OCHamcrest/HCSelfDescribing.h
+++ b/Source/include/OCHamcrest/HCSelfDescribing.h
@@ -1,0 +1,1 @@
+../../Core/HCSelfDescribing.h

--- a/Source/include/OCHamcrest/HCStringContains.h
+++ b/Source/include/OCHamcrest/HCStringContains.h
@@ -1,0 +1,1 @@
+../../Library/Text/HCStringContains.h

--- a/Source/include/OCHamcrest/HCStringContainsInOrder.h
+++ b/Source/include/OCHamcrest/HCStringContainsInOrder.h
@@ -1,0 +1,1 @@
+../../Library/Text/HCStringContainsInOrder.h

--- a/Source/include/OCHamcrest/HCStringDescription.h
+++ b/Source/include/OCHamcrest/HCStringDescription.h
@@ -1,0 +1,1 @@
+../../Core/HCStringDescription.h

--- a/Source/include/OCHamcrest/HCStringEndsWith.h
+++ b/Source/include/OCHamcrest/HCStringEndsWith.h
@@ -1,0 +1,1 @@
+../../Library/Text/HCStringEndsWith.h

--- a/Source/include/OCHamcrest/HCStringStartsWith.h
+++ b/Source/include/OCHamcrest/HCStringStartsWith.h
@@ -1,0 +1,1 @@
+../../Library/Text/HCStringStartsWith.h

--- a/Source/include/OCHamcrest/HCSubstringMatcher.h
+++ b/Source/include/OCHamcrest/HCSubstringMatcher.h
@@ -1,0 +1,1 @@
+../../Library/Text/HCSubstringMatcher.h

--- a/Source/include/OCHamcrest/HCTestFailure.h
+++ b/Source/include/OCHamcrest/HCTestFailure.h
@@ -1,0 +1,1 @@
+../../Core/Helpers/TestFailureReporters/HCTestFailure.h

--- a/Source/include/OCHamcrest/HCTestFailureReporter.h
+++ b/Source/include/OCHamcrest/HCTestFailureReporter.h
@@ -1,0 +1,1 @@
+../../Core/Helpers/TestFailureReporters/HCTestFailureReporter.h

--- a/Source/include/OCHamcrest/HCTestFailureReporterChain.h
+++ b/Source/include/OCHamcrest/HCTestFailureReporterChain.h
@@ -1,0 +1,1 @@
+../../Core/Helpers/TestFailureReporters/HCTestFailureReporterChain.h

--- a/Source/include/OCHamcrest/HCThrowsException.h
+++ b/Source/include/OCHamcrest/HCThrowsException.h
@@ -1,0 +1,1 @@
+../../Library/Object/HCThrowsException.h

--- a/Source/include/OCHamcrest/HCWrapInMatcher.h
+++ b/Source/include/OCHamcrest/HCWrapInMatcher.h
@@ -1,0 +1,1 @@
+../../Core/Helpers/HCWrapInMatcher.h

--- a/Source/include/OCHamcrest/OCHamcrest.h
+++ b/Source/include/OCHamcrest/OCHamcrest.h
@@ -1,0 +1,1 @@
+../../OCHamcrest.h


### PR DESCRIPTION
- added Package.swift
- added bunch of symlinks so SwiftPM can find the headers
- changed some to angle bracket ones, e.g.: `#import <OCHamcrest/HCAnyOf.h>` to satisfy Swift PM