### PR TITLE
Make the OCHamcrest Xcode framework a multiplatform binary framework bundle and add support for arm64e and arm64_32 architectures

### DIFF
--- a/Source/OCHamcrest.xcodeproj/project.pbxproj
+++ b/Source/OCHamcrest.xcodeproj/project.pbxproj
@@ -2388,10 +2388,18 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 0E49BBDB1C47498C00418A3C /* XcodeWarnings.xcconfig */;
 			buildSettings = {
+				ARCHS = (
+					"$(ARCHS_STANDARD)",
+					arm64e,
+					arm64_32,
+				);
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				FRAMEWORK_VERSION = A;
 				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx watchos watchsimulator";
+				SUPPORTS_MACCATALYST = NO;
+				TARGETED_DEVICE_FAMILY = "1,2,4";
 				WRAPPER_EXTENSION = framework;
 			};
 			name = Debug;
@@ -2400,10 +2408,18 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 0E49BBDB1C47498C00418A3C /* XcodeWarnings.xcconfig */;
 			buildSettings = {
+				ARCHS = (
+					"$(ARCHS_STANDARD)",
+					arm64e,
+					arm64_32,
+				);
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				FRAMEWORK_VERSION = A;
 				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx watchos watchsimulator";
+				SUPPORTS_MACCATALYST = NO;
+				TARGETED_DEVICE_FAMILY = "1,2,4";
 				WRAPPER_EXTENSION = framework;
 			};
 			name = Release;


### PR DESCRIPTION
Make the OCHamcrest Xcode framework a multiplatform binary framework bundle that allows this one bundle to be used across different platform targets (mac, iOS, and watchOS). More details can be found at https://developer.apple.com/documentation/xcode/creating-a-multi-platform-binary-framework-bundle

This also adds support for the arm64e architecture (https://developer.apple.com/documentation/security/preparing-your-app-to-work-with-pointer-authentication?language=objc) and the arm64_32 architecture (used on the watch).