### PR TITLE
Fix bug in makeXCFramework.sh

### DIFF
--- a/Resources/makeXCFramework.sh
+++ b/Resources/makeXCFramework.sh
@@ -5,6 +5,7 @@
 # macOS on Intel architecture since the `-destination generic/platform=visionOS ...` is missing on
 # that architecture.
 
+XCODE_PROJECT_PATH="../OCHamcrest.xcodeproj"
 FRAMEWORK_NAME="OCHamcrest"
 
 MACOS_ARCHIVE_PATH="./build/archives/macos.xcarchive"
@@ -18,16 +19,16 @@ WATCH_SIMULATOR_ARCHIVE_PATH="./build/archives/watch_sim.xcarchive"
 XR_ARCHIVE_PATH="./build/archives/xr.xcarchive"
 XR_SIMULATOR_ARCHIVE_PATH="./build/archives/xr_sim.xcarchive"
 
-xcodebuild archive -scheme ${FRAMEWORK_NAME} -archivePath ${MACOS_ARCHIVE_PATH} -sdk macosx SKIP_INSTALL=NO
-xcodebuild archive -scheme ${FRAMEWORK_NAME} -archivePath ${CATALYST_ARCHIVE_PATH} -destination 'generic/platform=macOS,variant=Mac Catalyst' SKIP_INSTALL=NO
-xcodebuild archive -scheme ${FRAMEWORK_NAME} -archivePath ${IOS_ARCHIVE_PATH} -sdk iphoneos -destination "generic/platform=iOS" SKIP_INSTALL=NO
-xcodebuild archive -scheme ${FRAMEWORK_NAME} -archivePath ${IOS_SIMULATOR_ARCHIVE_PATH} -sdk iphonesimulator -destination "generic/platform=iOS Simulator" SKIP_INSTALL=NO
-xcodebuild archive -scheme ${FRAMEWORK_NAME} -archivePath ${TV_ARCHIVE_PATH} -sdk appletvos -destination "generic/platform=tvOS" SKIP_INSTALL=NO
-xcodebuild archive -scheme ${FRAMEWORK_NAME} -archivePath ${TV_SIMULATOR_ARCHIVE_PATH} -sdk appletvsimulator -destination "generic/platform=tvOS Simulator" SKIP_INSTALL=NO
-xcodebuild archive -scheme ${FRAMEWORK_NAME} -archivePath ${WATCH_ARCHIVE_PATH} -sdk watchos -destination "generic/platform=watchOS" SKIP_INSTALL=NO
-xcodebuild archive -scheme ${FRAMEWORK_NAME} -archivePath ${WATCH_SIMULATOR_ARCHIVE_PATH} -sdk watchsimulator -destination "generic/platform=watchOS Simulator" SKIP_INSTALL=NO
-xcodebuild archive -scheme ${FRAMEWORK_NAME} -archivePath ${XR_ARCHIVE_PATH} -sdk xros -destination "generic/platform=visionOS" SKIP_INSTALL=NO
-xcodebuild archive -scheme ${FRAMEWORK_NAME} -archivePath ${XR_SIMULATOR_ARCHIVE_PATH} -sdk xrsimulator -destination "generic/platform=visionOS Simulator" SKIP_INSTALL=NO
+xcodebuild archive -project ${XCODE_PROJECT_PATH} -scheme ${FRAMEWORK_NAME} -archivePath ${MACOS_ARCHIVE_PATH} -sdk macosx SKIP_INSTALL=NO
+xcodebuild archive -project ${XCODE_PROJECT_PATH} -scheme ${FRAMEWORK_NAME} -archivePath ${CATALYST_ARCHIVE_PATH} -destination 'generic/platform=macOS,variant=Mac Catalyst' SKIP_INSTALL=NO
+xcodebuild archive -project ${XCODE_PROJECT_PATH} -scheme ${FRAMEWORK_NAME} -archivePath ${IOS_ARCHIVE_PATH} -sdk iphoneos -destination "generic/platform=iOS" SKIP_INSTALL=NO
+xcodebuild archive -project ${XCODE_PROJECT_PATH} -scheme ${FRAMEWORK_NAME} -archivePath ${IOS_SIMULATOR_ARCHIVE_PATH} -sdk iphonesimulator -destination "generic/platform=iOS Simulator" SKIP_INSTALL=NO
+xcodebuild archive -project ${XCODE_PROJECT_PATH} -scheme ${FRAMEWORK_NAME} -archivePath ${TV_ARCHIVE_PATH} -sdk appletvos -destination "generic/platform=tvOS" SKIP_INSTALL=NO
+xcodebuild archive -project ${XCODE_PROJECT_PATH} -scheme ${FRAMEWORK_NAME} -archivePath ${TV_SIMULATOR_ARCHIVE_PATH} -sdk appletvsimulator -destination "generic/platform=tvOS Simulator" SKIP_INSTALL=NO
+xcodebuild archive -project ${XCODE_PROJECT_PATH} -scheme ${FRAMEWORK_NAME} -archivePath ${WATCH_ARCHIVE_PATH} -sdk watchos -destination "generic/platform=watchOS" SKIP_INSTALL=NO
+xcodebuild archive -project ${XCODE_PROJECT_PATH} -scheme ${FRAMEWORK_NAME} -archivePath ${WATCH_SIMULATOR_ARCHIVE_PATH} -sdk watchsimulator -destination "generic/platform=watchOS Simulator" SKIP_INSTALL=NO
+xcodebuild archive -project ${XCODE_PROJECT_PATH} -scheme ${FRAMEWORK_NAME} -archivePath ${XR_ARCHIVE_PATH} -sdk xros -destination "generic/platform=visionOS" SKIP_INSTALL=NO
+xcodebuild archive -project ${XCODE_PROJECT_PATH} -scheme ${FRAMEWORK_NAME} -archivePath ${XR_SIMULATOR_ARCHIVE_PATH} -sdk xrsimulator -destination "generic/platform=visionOS Simulator" SKIP_INSTALL=NO
 
 xcodebuild -create-xcframework \
   -archive ${MACOS_ARCHIVE_PATH} -framework ${FRAMEWORK_NAME}.framework \


### PR DESCRIPTION
My previous pull request #99 accidentally broke the xcframework script. This commit restores the functionality by adding the `-project` argument to the xcodebuild command which points to the location of `OCHamcrest.xcodeproj` in the root folder. Sorry for the inconvenience.