### PR TITLE
Fix makeXCFramework.sh script

### DIFF
--- a/OCHamcrest.xcodeproj/project.pbxproj
+++ b/OCHamcrest.xcodeproj/project.pbxproj
@@ -1307,7 +1307,6 @@
 				FRAMEWORK_VERSION = A;
 				INFOPLIST_FILE = "$(SOURCE_ROOT)/Resources/OCHamcrest-Info.plist";
 				SDKROOT = macosx;
-				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator macosx watchos watchsimulator xros xrsimulator";
 				SUPPORTS_MACCATALYST = YES;
 				TARGETED_DEVICE_FAMILY = "1,2,3,4,7";
 				WRAPPER_EXTENSION = framework;
@@ -1328,7 +1327,6 @@
 				FRAMEWORK_VERSION = A;
 				INFOPLIST_FILE = "$(SOURCE_ROOT)/Resources/OCHamcrest-Info.plist";
 				SDKROOT = macosx;
-				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator macosx watchos watchsimulator xros xrsimulator";
 				SUPPORTS_MACCATALYST = YES;
 				TARGETED_DEVICE_FAMILY = "1,2,3,4,7";
 				WRAPPER_EXTENSION = framework;

--- a/Resources/makeXCFramework.sh
+++ b/Resources/makeXCFramework.sh
@@ -19,16 +19,16 @@ WATCH_SIMULATOR_ARCHIVE_PATH="./build/archives/watch_sim.xcarchive"
 XR_ARCHIVE_PATH="./build/archives/xr.xcarchive"
 XR_SIMULATOR_ARCHIVE_PATH="./build/archives/xr_sim.xcarchive"
 
-xcodebuild archive -project ${XCODE_PROJECT_PATH} -scheme ${FRAMEWORK_NAME} -archivePath ${MACOS_ARCHIVE_PATH} -sdk macosx SKIP_INSTALL=NO
+xcodebuild archive -project ${XCODE_PROJECT_PATH} -scheme ${FRAMEWORK_NAME} -archivePath ${MACOS_ARCHIVE_PATH} -destination 'generic/platform=macOS' SKIP_INSTALL=NO
 xcodebuild archive -project ${XCODE_PROJECT_PATH} -scheme ${FRAMEWORK_NAME} -archivePath ${CATALYST_ARCHIVE_PATH} -destination 'generic/platform=macOS,variant=Mac Catalyst' SKIP_INSTALL=NO
-xcodebuild archive -project ${XCODE_PROJECT_PATH} -scheme ${FRAMEWORK_NAME} -archivePath ${IOS_ARCHIVE_PATH} -sdk iphoneos -destination "generic/platform=iOS" SKIP_INSTALL=NO
-xcodebuild archive -project ${XCODE_PROJECT_PATH} -scheme ${FRAMEWORK_NAME} -archivePath ${IOS_SIMULATOR_ARCHIVE_PATH} -sdk iphonesimulator -destination "generic/platform=iOS Simulator" SKIP_INSTALL=NO
-xcodebuild archive -project ${XCODE_PROJECT_PATH} -scheme ${FRAMEWORK_NAME} -archivePath ${TV_ARCHIVE_PATH} -sdk appletvos -destination "generic/platform=tvOS" SKIP_INSTALL=NO
-xcodebuild archive -project ${XCODE_PROJECT_PATH} -scheme ${FRAMEWORK_NAME} -archivePath ${TV_SIMULATOR_ARCHIVE_PATH} -sdk appletvsimulator -destination "generic/platform=tvOS Simulator" SKIP_INSTALL=NO
-xcodebuild archive -project ${XCODE_PROJECT_PATH} -scheme ${FRAMEWORK_NAME} -archivePath ${WATCH_ARCHIVE_PATH} -sdk watchos -destination "generic/platform=watchOS" SKIP_INSTALL=NO
-xcodebuild archive -project ${XCODE_PROJECT_PATH} -scheme ${FRAMEWORK_NAME} -archivePath ${WATCH_SIMULATOR_ARCHIVE_PATH} -sdk watchsimulator -destination "generic/platform=watchOS Simulator" SKIP_INSTALL=NO
-xcodebuild archive -project ${XCODE_PROJECT_PATH} -scheme ${FRAMEWORK_NAME} -archivePath ${XR_ARCHIVE_PATH} -sdk xros -destination "generic/platform=visionOS" SKIP_INSTALL=NO
-xcodebuild archive -project ${XCODE_PROJECT_PATH} -scheme ${FRAMEWORK_NAME} -archivePath ${XR_SIMULATOR_ARCHIVE_PATH} -sdk xrsimulator -destination "generic/platform=visionOS Simulator" SKIP_INSTALL=NO
+xcodebuild archive -project ${XCODE_PROJECT_PATH} -scheme ${FRAMEWORK_NAME} -archivePath ${IOS_ARCHIVE_PATH} -destination "generic/platform=iOS" SKIP_INSTALL=NO
+xcodebuild archive -project ${XCODE_PROJECT_PATH} -scheme ${FRAMEWORK_NAME} -archivePath ${IOS_SIMULATOR_ARCHIVE_PATH} -destination "generic/platform=iOS Simulator" SKIP_INSTALL=NO
+xcodebuild archive -project ${XCODE_PROJECT_PATH} -scheme ${FRAMEWORK_NAME} -archivePath ${TV_ARCHIVE_PATH} -destination "generic/platform=tvOS" SKIP_INSTALL=NO
+xcodebuild archive -project ${XCODE_PROJECT_PATH} -scheme ${FRAMEWORK_NAME} -archivePath ${TV_SIMULATOR_ARCHIVE_PATH} -destination "generic/platform=tvOS Simulator" SKIP_INSTALL=NO
+xcodebuild archive -project ${XCODE_PROJECT_PATH} -scheme ${FRAMEWORK_NAME} -archivePath ${WATCH_ARCHIVE_PATH} -destination "generic/platform=watchOS" SKIP_INSTALL=NO
+xcodebuild archive -project ${XCODE_PROJECT_PATH} -scheme ${FRAMEWORK_NAME} -archivePath ${WATCH_SIMULATOR_ARCHIVE_PATH} -destination "generic/platform=watchOS Simulator" SKIP_INSTALL=NO
+xcodebuild archive -project ${XCODE_PROJECT_PATH} -scheme ${FRAMEWORK_NAME} -archivePath ${XR_ARCHIVE_PATH} -destination "generic/platform=visionOS" SKIP_INSTALL=NO
+xcodebuild archive -project ${XCODE_PROJECT_PATH} -scheme ${FRAMEWORK_NAME} -archivePath ${XR_SIMULATOR_ARCHIVE_PATH} -destination "generic/platform=visionOS Simulator" SKIP_INSTALL=NO
 
 xcodebuild -create-xcframework \
   -archive ${MACOS_ARCHIVE_PATH} -framework ${FRAMEWORK_NAME}.framework \


### PR DESCRIPTION
I accidentally introduced a bug in #97 as I changed the `archive` commands in `makeXCFramework.sh`. Now the archive command follows the description from "[Creating a multiplatform binary framework bundle](https://developer.apple.com/documentation/xcode/creating-a-multi-platform-binary-framework-bundle)" and leaves out the `-sdk` which is currently present.

Additionally I also removed the usage of `SUPPORTED_PLATFORMS` from the xcproj file as it should use the value defined in `<PROJECT_ROOT>/Resources/XcodeTargets.xcconfig`.